### PR TITLE
Update Alpine base to 3.24.1

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,10 +1,10 @@
 kind: pipeline
 type: docker
-name: 3.23-alpine-amd64
+name: 3.24-alpine-amd64
 
 trigger:
   branch:
-    - '3.23'
+    - '3.24'
   event:
     - pull_request
 
@@ -26,10 +26,10 @@ steps:
       repo:
         from_secret: docker_repo_alpine
       tags:
-        - '3.23'
-        - '3.23-drone-build-${DRONE_BUILD_NUMBER}-amd64'
-        - '3.23.3'
-        - '3.23.3-drone-build-${DRONE_BUILD_NUMBER}-amd64'
+        - '3.24'
+        - '3.24-drone-build-${DRONE_BUILD_NUMBER}-amd64'
+        - '3.24.1'
+        - '3.24.1-drone-build-${DRONE_BUILD_NUMBER}-amd64'
 
   # Slack notification
   - name: slack-notification

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,11 +9,11 @@
 ## Build, Test, and Development Commands
 - Build locally:
   ```sh
-  docker build -t kernel528/alpine:3.23.3 -f Dockerfile .
+  docker build -t kernel528/alpine:3.24.1 -f Dockerfile .
   ```
 - Run a quick smoke test:
   ```sh
-  docker run -it --rm --name alpine3 kernel528/alpine:3.23.3 bash
+  docker run -it --rm --name alpine3 kernel528/alpine:3.24.1 bash
   ```
 
 ## Coding Style & Naming Conventions
@@ -26,8 +26,8 @@
 - When changing shell config files, confirm the container starts with the expected shell (`/bin/zsh`) and that `sudo` works for the default user.
 
 ## Commit & Pull Request Guidelines
-- Commit messages are concise and descriptive (e.g., “Updated to alpine 3.23.3 release.”).
-- Branch flow: create a full-version branch (e.g., `3.23.3`), merge to `3.23`, then merge to `main` and tag the release.
+- Commit messages are concise and descriptive (e.g., “Updated to alpine 3.24.1 release.”).
+- Branch flow: create a full-version branch (e.g., `3.24.1`), merge to `3.24`, then merge to `main` and tag the release.
 - PRs should update `VERSION.md`, `README.md` examples, and `.drone.yml` tags as needed.
 
 ## Security & Configuration Tips

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.23.3
+FROM alpine:3.24.1
 
 # Default to UTF-8 file.encoding
 ENV LANG=C.UTF-8

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Build Status](http://drone.kernelsanders.biz:8080/api/badges/kernel528/alpine-docker/status.svg)](http://drone.kernelsanders.biz:8080/kernel528/alpine-docker)
 [![Latest Version](https://img.shields.io/github/v/tag/kernel528/alpine-docker)](https://github.com/kernel528/alpine-docker/releases/latest)
 [![Docker Pulls](https://img.shields.io/docker/pulls/kernel528/alpine)](https://hub.docker.com/r/kernel528/alpine)
-[![Docker Image Size (tag)](https://img.shields.io/docker/image-size/kernel528/alpine/3.23.3)](https://hub.docker.com/r/kernel528/alpine/3.23.3)
+[![Docker Image Size (tag)](https://img.shields.io/docker/image-size/kernel528/alpine/3.24.1)](https://hub.docker.com/r/kernel528/alpine/3.24.1)
 [![Docker Image Version (latest semver)](https://img.shields.io/docker/v/kernel528/alpine?sort=semver)](https://hub.docker.com/r/kernel528/alpine)
 
 # This repo contains the base docker image for kernel528
@@ -14,18 +14,18 @@ This base image builds on Alpine Linux and adds common utilities plus a default 
 
 ## Build
 ```
-docker build -t kernel528/alpine:3.23.3 -f Dockerfile .
+docker build -t kernel528/alpine:3.24.1 -f Dockerfile .
 ```
 
 ## Run
 ```
-docker run -it --rm --name alpine3 --hostname docker-alpine3 -e TZ=CST kernel528/alpine:3.23.3 bash
+docker run -it --rm --name alpine3 --hostname docker-alpine3 -e TZ=CST kernel528/alpine:3.24.1 bash
 ```
 
 ## Use in downstream images
 Add this to your downstream Dockerfile:
 ```
-FROM kernel528/alpine:3.23.3
+FROM kernel528/alpine:3.24.1
 ```
 
 

--- a/VERSION.md
+++ b/VERSION.md
@@ -50,3 +50,4 @@
 * 3.22.2 - Updated to alpine 3.22.2 release.
 * 3.23.2 - Updated to alpine 3.23.2 release.
 * 3.23.3 - Updated to alpine 3.23.3 release.
+* 3.24.1 - Updated to alpine 3.24.1 release.


### PR DESCRIPTION
## Summary
- update base image to alpine:3.24.1
- update README, VERSION.md, AGENTS.md, and Drone 3.24 branch tags
- configure Drone version pipeline for the 3.24 branch

## Validation
- docker image build --no-cache -t kernel528/alpine:3.24.1 -f Dockerfile .
- docker container run --rm kernel528/alpine:3.24.1 cat /etc/alpine-release
- docker container run --rm kernel528/alpine:3.24.1 sh -lc 'id && printf "%s\n" "/usr/bin/zsh" && zsh --version'
- docker container run --rm kernel528/alpine:3.24.1 sh -lc 'sudo -n true && echo sudo-ok'