### PR TITLE
Update Umbraco CMS security dependency

### DIFF
--- a/.oh-my-posh/src/test/umbraco/MyProject.csproj
+++ b/.oh-my-posh/src/test/umbraco/MyProject.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>
@@ -10,7 +10,7 @@
         <PackageReference Include="Umbraco.TheStarterKit" Version="11.0.0" />
         <!-- This is a comment -->
         <!--PackageReference Include="Umbraco.Cms" Version="12.3.4" /-->
-        <PackageReference Include="Umbraco.Cms" Version="13.12.1" />
+        <PackageReference Include="Umbraco.Cms" Version="13.14.0" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
## Summary
- update `Umbraco.Cms` from `13.12.1` to `13.14.0` to address the open security advisory
- retarget the test project from `net7.0` to `net8.0`, required by Umbraco CMS 13.14.0

## Validation
- `git diff --check` passed
- NuGet package metadata confirms Umbraco CMS 13.14.0 targets `net8.0`
- .NET build was not run because the current environment does not have the `dotnet` CLI installed

Closes the applicable Umbraco Dependabot alert.