### PR TITLE
Potential fix for code scanning alert no. 1: Incorrect conversion between integer types

### DIFF
--- a/.oh-my-posh/src/cli/image/config.go
+++ b/.oh-my-posh/src/cli/image/config.go
@@ -73,16 +73,16 @@ func (color HexColor) RGB() (*RGB, error) {
 		return nil, fmt.Errorf("invalid hex color format: %s", hex)
 	}
 
-	var r, g, b int64
+	var r, g, b uint64
 	var err error
 
-	if r, err = strconv.ParseInt(hex[0:2], 16, 64); err != nil {
+	if r, err = strconv.ParseUint(hex[0:2], 16, 8); err != nil {
 		return nil, err
 	}
-	if g, err = strconv.ParseInt(hex[2:4], 16, 64); err != nil {
+	if g, err = strconv.ParseUint(hex[2:4], 16, 8); err != nil {
 		return nil, err
 	}
-	if b, err = strconv.ParseInt(hex[4:6], 16, 64); err != nil {
+	if b, err = strconv.ParseUint(hex[4:6], 16, 8); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
Potential fix for [https://github.com/kernel528/alpine-docker/security/code-scanning/1](https://github.com/kernel528/alpine-docker/security/code-scanning/1)

Use `strconv.ParseUint` with an explicit bit size of `8` for RGB channels, then convert from `uint64` to `int`. This aligns parsing width with expected domain (`00`-`FF`) and removes the risky “parse wide then narrow” pattern.

Best single fix in `.oh-my-posh/src/cli/image/config.go`:
- In `HexColor.RGB()`, change `r, g, b` from `int64` to `uint64`.
- Replace three `strconv.ParseInt(..., 16, 64)` calls with `strconv.ParseUint(..., 16, 8)`.
- Keep return construction as `&RGB{int(r), int(g), int(b)}`.

No new imports or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
