### PR TITLE
Potential fix for code scanning alert no. 2: Incorrect conversion between integer types

### DIFF
--- a/.oh-my-posh/src/cli/image/config.go
+++ b/.oh-my-posh/src/cli/image/config.go
@@ -76,13 +76,13 @@ func (color HexColor) RGB() (*RGB, error) {
 	var r, g, b int64
 	var err error
 
-	if r, err = strconv.ParseInt(hex[0:2], 16, 64); err != nil {
+	if r, err = strconv.ParseInt(hex[0:2], 16, 32); err != nil {
 		return nil, err
 	}
-	if g, err = strconv.ParseInt(hex[2:4], 16, 64); err != nil {
+	if g, err = strconv.ParseInt(hex[2:4], 16, 32); err != nil {
 		return nil, err
 	}
-	if b, err = strconv.ParseInt(hex[4:6], 16, 64); err != nil {
+	if b, err = strconv.ParseInt(hex[4:6], 16, 32); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
Potential fix for [https://github.com/kernel528/alpine-docker/security/code-scanning/2](https://github.com/kernel528/alpine-docker/security/code-scanning/2)

Use `strconv.ParseInt` with a 32-bit target size (or smaller) instead of 64-bit for RGB byte parsing, so the parsed type is already bounded and no risky narrowing from 64-bit is involved. This preserves behavior because valid values remain `0..255`, errors remain errors, and output is unchanged.

In `.oh-my-posh/src/cli/image/config.go`, inside `HexColor.RGB()`, change the three calls:
- `strconv.ParseInt(hex[0:2], 16, 64)`
- `strconv.ParseInt(hex[2:4], 16, 64)`
- `strconv.ParseInt(hex[4:6], 16, 64)`

to use bit size `32` (or `8`; `32` is a minimal-diff choice while still removing the reported 64-bit-to-int narrowing concern). No new imports, methods, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
