### PR TITLE
Potential fix for code scanning alert no. 3: Incorrect conversion between integer types

### DIFF
--- a/.oh-my-posh/src/cli/image/config.go
+++ b/.oh-my-posh/src/cli/image/config.go
@@ -73,16 +73,16 @@ func (color HexColor) RGB() (*RGB, error) {
 		return nil, fmt.Errorf("invalid hex color format: %s", hex)
 	}
 
-	var r, g, b int64
+	var r, g, b uint64
 	var err error
 
-	if r, err = strconv.ParseInt(hex[0:2], 16, 64); err != nil {
+	if r, err = strconv.ParseUint(hex[0:2], 16, 8); err != nil {
 		return nil, err
 	}
-	if g, err = strconv.ParseInt(hex[2:4], 16, 64); err != nil {
+	if g, err = strconv.ParseUint(hex[2:4], 16, 8); err != nil {
 		return nil, err
 	}
-	if b, err = strconv.ParseInt(hex[4:6], 16, 64); err != nil {
+	if b, err = strconv.ParseUint(hex[4:6], 16, 8); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
Potential fix for [https://github.com/kernel528/alpine-docker/security/code-scanning/3](https://github.com/kernel528/alpine-docker/security/code-scanning/3)

Use parsing APIs with the exact required bit size for color channels (8 bits), instead of parsing as 64-bit signed integers and later converting.  
In `.oh-my-posh/src/cli/image/config.go`, update `HexColor.RGB()` to:

- Replace `int64` temporaries (`r, g, b`) with `uint64` temporaries (to match `ParseUint` return type).
- Replace `strconv.ParseInt(..., 16, 64)` with `strconv.ParseUint(..., 16, 8)` for all three channels.
- Keep final conversion to `int` when constructing `RGB`; converting values constrained to `[0,255]` is safe and preserves behavior.

No new imports are needed because `strconv` is already imported.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
