### PR TITLE
Prepare Alpine 3.24.1_1 release

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -28,8 +28,8 @@ steps:
       tags:
         - '3.24'
         - '3.24-drone-build-${DRONE_BUILD_NUMBER}-amd64'
-        - '3.24.1'
-        - '3.24.1-drone-build-${DRONE_BUILD_NUMBER}-amd64'
+        - '3.24.1_1'
+        - '3.24.1_1-drone-build-${DRONE_BUILD_NUMBER}-amd64'
 
   # Slack notification
   - name: slack-notification

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,11 +9,11 @@
 ## Build, Test, and Development Commands
 - Build locally:
   ```sh
-  docker build -t kernel528/alpine:3.24.1 -f Dockerfile .
+  docker build -t kernel528/alpine:3.24.1_1 -f Dockerfile .
   ```
 - Run a quick smoke test:
   ```sh
-  docker run -it --rm --name alpine3 kernel528/alpine:3.24.1 bash
+  docker run -it --rm --name alpine3 kernel528/alpine:3.24.1_1 bash
   ```
 
 ## Coding Style & Naming Conventions
@@ -26,8 +26,8 @@
 - When changing shell config files, confirm the container starts with the expected shell (`/bin/zsh`) and that `sudo` works for the default user.
 
 ## Commit & Pull Request Guidelines
-- Commit messages are concise and descriptive (e.g., “Updated to alpine 3.24.1 release.”).
-- Branch flow: create a full-version branch (e.g., `3.24.1`), merge to `3.24`, then merge to `main` and tag the release.
+- Commit messages are concise and descriptive (e.g., “Refresh Alpine 3.24.1 image dependencies.”).
+- Branch flow: create a full-version branch (e.g., `3.24.1_1`), merge to `3.24`, then merge to `main` and tag the release.
 - PRs should update `VERSION.md`, `README.md` examples, and `.drone.yml` tags as needed.
 
 ## Security & Configuration Tips

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Build Status](http://drone.kernelsanders.biz:8080/api/badges/kernel528/alpine-docker/status.svg)](http://drone.kernelsanders.biz:8080/kernel528/alpine-docker)
 [![Latest Version](https://img.shields.io/github/v/tag/kernel528/alpine-docker)](https://github.com/kernel528/alpine-docker/releases/latest)
 [![Docker Pulls](https://img.shields.io/docker/pulls/kernel528/alpine)](https://hub.docker.com/r/kernel528/alpine)
-[![Docker Image Size (tag)](https://img.shields.io/docker/image-size/kernel528/alpine/3.24.1)](https://hub.docker.com/r/kernel528/alpine/3.24.1)
+[![Docker Image Size (tag)](https://img.shields.io/docker/image-size/kernel528/alpine/3.24.1_1)](https://hub.docker.com/r/kernel528/alpine/3.24.1_1)
 [![Docker Image Version (latest semver)](https://img.shields.io/docker/v/kernel528/alpine?sort=semver)](https://hub.docker.com/r/kernel528/alpine)
 
 # This repo contains the base docker image for kernel528
@@ -14,18 +14,18 @@ This base image builds on Alpine Linux and adds common utilities plus a default 
 
 ## Build
 ```
-docker build -t kernel528/alpine:3.24.1 -f Dockerfile .
+docker build -t kernel528/alpine:3.24.1_1 -f Dockerfile .
 ```
 
 ## Run
 ```
-docker run -it --rm --name alpine3 --hostname docker-alpine3 -e TZ=CST kernel528/alpine:3.24.1 bash
+docker run -it --rm --name alpine3 --hostname docker-alpine3 -e TZ=CST kernel528/alpine:3.24.1_1 bash
 ```
 
 ## Use in downstream images
 Add this to your downstream Dockerfile:
 ```
-FROM kernel528/alpine:3.24.1
+FROM kernel528/alpine:3.24.1_1
 ```
 
 

--- a/VERSION.md
+++ b/VERSION.md
@@ -51,3 +51,4 @@
 * 3.23.2 - Updated to alpine 3.23.2 release.
 * 3.23.3 - Updated to alpine 3.23.3 release.
 * 3.24.1 - Updated to alpine 3.24.1 release.
+* 3.24.1_1 - Refreshed shell dependencies and security patches on Alpine 3.24.1.


### PR DESCRIPTION
## Summary
- prepare the Alpine 3.24.1_1 image revision after the latest shell dependency and security patch merges
- update Drone version tags to publish 3.24.1_1 and build-number variants
- update release history, README examples, and repository guidance

## Release ancestry
- release branch contains patched 3.24 commit db30fa7 from PR #177
- patch was propagated to main by PR #178
- no 3.24.1_1 Git tag exists yet

## Validation
- docker image build --no-cache --platform linux/amd64 -t kernel528/alpine:3.24.1_1 -f Dockerfile .
- confirmed Alpine 3.24.1 and x86_64 runtime
- confirmed default user joe and SHELL=/bin/zsh
- confirmed bash, zsh, sudo, curl, and git are available
- confirmed passwordless sudo with sudo -n true
- confirmed clean zsh startup with zsh -f
- local image digest: sha256:4778b300b4313942e24e5f435706b1f3839e62dad63f3be8dd1421b09dd3271b

## Security review note
Open Dependabot alerts remain in copied upstream development metadata:
- critical: websocket-driver < 0.7.5 in .oh-my-posh/website/package-lock.json
- high: urllib3 < 2.7.0 in .oh-my-zsh/.github/workflows/dependencies/requirements.txt (2 advisories)

These dependencies are not installed by the Dockerfile, but the vendored files are copied into the image. Review or patch before tagging if repository policy requires zero critical/high alerts.

## Release sequence
1. Merge this PR into 3.24 after Drone succeeds and security alerts are accepted or resolved.
2. Merge updated 3.24 into main.
3. Create GitHub tag/release 3.24.1_1 from main.
4. Verify Drone publishes kernel528/alpine:3.24.1_1 before downstream refreshes.